### PR TITLE
[update] パイプラインのファイルコンフリクトを解消

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -17,7 +17,7 @@ stages:
     cmd: >-
       poetry run python -m src.features.build_features
       data/interim/dataset.parquet
-      data/interim/sentences.parquet
+      models/${item.embedding_model}/sentences_${item.embedding_method}.cloudpickle
       models/${item.embedding_model}/embeddings_${item.embedding_method}.cloudpickle
       --mlflow_run_name=pipeline
       --model_name_or_filepath=${item.embedding_model}
@@ -28,7 +28,7 @@ stages:
     - src/models/vector_engine.py
     - data/interim/dataset.parquet
     outs:
-    - data/interim/sentences.parquet
+    - models/${item.embedding_model}/sentences_${item.embedding_method}.cloudpickle
     - models/${item.embedding_model}/embeddings_${item.embedding_method}.cloudpickle
 
   build_vector_db:
@@ -37,14 +37,14 @@ stages:
       embedding_method: ${embedding_methods}
     cmd: >-
       poetry run python -m src.features.build_vector_db
-      data/interim/sentences.parquet
+      models/${item.embedding_model}/sentences_${item.embedding_method}.cloudpickle
       models/${item.embedding_model}/embeddings_${item.embedding_method}.cloudpickle
       models/${item.embedding_model}/engine_${item.embedding_method}.cloudpickle
       --mlflow_run_name=pipeline
     deps:
     - src/features/build_vector_db.py
     - src/models/vector_engine.py
-    - data/interim/sentences.parquet
+    - models/${item.embedding_model}/sentences_${item.embedding_method}.cloudpickle
     - models/${item.embedding_model}/embeddings_${item.embedding_method}.cloudpickle
     outs:
     - models/${item.embedding_model}/engine_${item.embedding_method}.cloudpickle


### PR DESCRIPTION
close #15 

dvc.yaml の sentences.parquet  ファイルの扱いを変更。DVCがパイプラインがクロスするのを避けるため。